### PR TITLE
Added fallback path for the multi-tenant.tenant-directory

### DIFF
--- a/src/HynMe/MultiTenant/Commands/SetupCommand.php
+++ b/src/HynMe/MultiTenant/Commands/SetupCommand.php
@@ -85,7 +85,8 @@ class SetupCommand extends Command
 
         $this->comment('In the following steps you will be asked to set up your first tenant website.');
 
-        $tenantDirectory = Config::get('multi-tenant.tenant-directory');
+        $tenantDirectory = Config::get('multi-tenant.tenant-directory') ? Config::get('multi-tenant.tenant-directory') : storage_path('multi-tenant');
+
 
         if(!File::isDirectory($tenantDirectory) && File::makeDirectory($tenantDirectory, 0755, true))
         {


### PR DESCRIPTION
The setup command fails when the tenant-directory is not in Config.
Added a fallback in line with HynMe\MultiTenant\Tenant\Directory.